### PR TITLE
Adds deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Github Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - adds-deploy-script
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        
+    - name: Publish
+      run: dotnet publish honk-site.csproj -c Release -o release --nologo
+      
+    - name: Prepare release
+      run: |
+        touch release/wwwroot/.nojekyll
+        cp release/wwwroot/index.html release/wwwroot/404.html
+      
+    - name: Commit wwwroot to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: release/wwwroot

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
         
     - name: Publish
       run: dotnet publish honk-site.csproj -c Release -o release --nologo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - main
-    - adds-deploy-script
 
 jobs:
   deploy:


### PR DESCRIPTION
Makes it so github automatically builds and deploys to the gh-pages branch for you, so you don't have to manually build and push it.