### PR TITLE
Fixes base url shenanigans

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       
     - name: Prepare release
       run: |
-        sed -i 's/<base href="\/"\/>/<base href="\/honk-site\/"\/>/g' release/wwwroot/index.html
+        sed -i 's/<base href="" \/>/<base href="\/honk-site\/"\/>/g' release/wwwroot/index.html
         touch release/wwwroot/.nojekyll
         cp release/wwwroot/index.html release/wwwroot/404.html
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
       
     - name: Prepare release
       run: |
+        sed -i 's/<base href="\/"\/>/<base href="\/honk-site\/"\/>/g' release/wwwroot/index.html
         touch release/wwwroot/.nojekyll
         cp release/wwwroot/index.html release/wwwroot/404.html
       


### PR DESCRIPTION
rapidfire PR number 2: I make it so that there's a little thing that find-and-replaces <base href="" /> with <base href="/honk_site/" /> because it's needed for proper handling of the base URL for redirects and images and stuff (this won't affect local testing)